### PR TITLE
Make Connect/Disconnect device context menu dynamic

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -5,253 +5,257 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-05-30 20:37+1000\n"
+"POT-Creation-Date: 2024-06-02 13:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=cp936\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: main.py:58 main.py:100 main.py:165
+#: main.py:59 main.py:101 main.py:166
 msgid "Initializing"
 msgstr ""
 
-#: main.py:59
+#: main.py:60
 msgid "Idle"
 msgstr ""
 
-#: main.py:60
+#: main.py:61
 msgid "Pairing"
 msgstr ""
 
-#: main.py:61
+#: main.py:62
 msgid "Connecting"
 msgstr ""
 
-#: main.py:62 main.py:72
+#: main.py:63 main.py:73
 msgid "Connected"
 msgstr ""
 
-#: main.py:63
+#: main.py:64
 msgid "Audio starting"
 msgstr ""
 
-#: main.py:64
+#: main.py:65
 msgid "Audio streaming"
 msgstr ""
 
-#: main.py:65
+#: main.py:66
 msgid "Audio stopping"
 msgstr ""
 
-#: main.py:66
+#: main.py:67
 msgid "Disconnecting"
 msgstr ""
 
-#: main.py:67
+#: main.py:68
 msgid "Voice starting"
 msgstr ""
 
-#: main.py:68
+#: main.py:69
 msgid "Voice streaming"
 msgstr ""
 
-#: main.py:69
+#: main.py:70
 msgid "Voice stopping"
 msgstr ""
 
-#: main.py:71 main.py:169
+#: main.py:72 main.py:170
 msgid "Disconnected"
 msgstr ""
 
-#: main.py:73
+#: main.py:74
 msgid "Unicast starting"
 msgstr ""
 
-#: main.py:74
+#: main.py:75
 msgid "Unicast streaming"
 msgstr ""
 
-#: main.py:75
+#: main.py:76
 msgid "Broadcast starting"
 msgstr ""
 
-#: main.py:76
+#: main.py:77
 msgid "Broadcast streaming"
 msgstr ""
 
-#: main.py:77
+#: main.py:78
 msgid "Streaming stopping"
 msgstr ""
 
-#: main.py:120
+#: main.py:121
 msgid "Audio Mode"
 msgstr ""
 
-#: main.py:122
+#: main.py:123
 msgid "LE Broadcast"
 msgstr ""
 
-#: main.py:124
+#: main.py:125
 msgid "Most Recently Used Devices"
 msgstr ""
 
-#: main.py:127
+#: main.py:128
 msgid "Window"
 msgstr ""
 
-#: main.py:130
-msgid "Help"
+#: main.py:131
+msgid "Settings"
 msgstr ""
 
-#: main.py:153
+#: main.py:154
 msgid "High Quality (one-to-one)"
 msgstr ""
 
-#: main.py:156
+#: main.py:157
 msgid "Gaming (one-to-one)"
 msgstr ""
 
-#: main.py:159
+#: main.py:160
 msgid "Broadcast"
 msgstr ""
 
-#: main.py:163
+#: main.py:164
 msgid "Dongle State"
 msgstr ""
 
-#: main.py:167
+#: main.py:168
 msgid "LE Audio State"
 msgstr ""
 
-#: main.py:171
+#: main.py:172
 msgid "Codec in Use"
 msgstr ""
 
-#: main.py:176
+#: main.py:177
 msgid "Prefer using LE audio for dual-mode devices"
 msgstr ""
 
-#: main.py:202
+#: main.py:203
 msgid "Public broadcast"
 msgstr ""
 
-#: main.py:223
+#: main.py:224
 msgid "Broadcast high-quality music, otherwise, voice"
 msgstr ""
 
-#: main.py:245
+#: main.py:246
 msgid "Encrypt broadcast; please set a key first"
 msgstr ""
 
-#: main.py:266
+#: main.py:267
 msgid "Broadcast Name, maximum 30 characters"
 msgstr ""
 
-#: main.py:281
+#: main.py:282
 msgid "Input a new name of no more than 30 characters then press <ENTER>"
 msgstr ""
 
-#: main.py:285
+#: main.py:286
 msgid "Broadcast Key, maximum 16 characters"
 msgstr ""
 
-#: main.py:300
+#: main.py:301
 msgid "Input a new key then press <ENTER>"
 msgstr ""
 
-#: main.py:322
+#: main.py:323
 msgid "Add device"
 msgstr ""
 
-#: main.py:338
-msgid "Connect/Disconnect"
-msgstr ""
-
-#: main.py:339
+#: main.py:340
 msgid "Delete"
 msgstr ""
 
-#: main.py:358
+#: main.py:349
+msgid "Connect"
+msgstr ""
+
+#: main.py:349
+msgid "Disconnect"
+msgstr ""
+
+#: main.py:368
 msgid "Clear All"
 msgstr ""
 
-#: main.py:417
+#: main.py:427
 msgid "Quit"
 msgstr ""
 
-#: main.py:417
+#: main.py:427
 msgid "Show Window"
 msgstr ""
 
-#: main.py:418
+#: main.py:428
 msgid "FlooGoo Bluetooth Audio Source"
 msgstr ""
 
-#: main.py:427
+#: main.py:437
 msgid "Minimize to System Tray"
 msgstr ""
 
-#: main.py:429
+#: main.py:439
 msgid "Quit App"
 msgstr ""
 
-#: main.py:464
+#: main.py:453
+msgid "LED"
+msgstr ""
+
+#: main.py:496
 msgid "Disconnect and reconnect the dongle to activate configuration changes, after which it will function independently without the app."
 msgstr ""
 
-#: main.py:479
+#: main.py:511
 msgid "Third-Party Software Licenses"
 msgstr ""
 
-#: main.py:482
+#: main.py:514
 msgid "Support Link"
 msgstr ""
 
-#: main.py:485
+#: main.py:517
 msgid "Version"
 msgstr ""
 
-#: main.py:508 main.py:617
+#: main.py:540 main.py:653
 msgid "Firmware"
 msgstr ""
 
-#: main.py:514
+#: main.py:546
 msgid "Upgrade error"
 msgstr ""
 
-#: main.py:520
+#: main.py:552
 msgid "Upgrade progress"
 msgstr ""
 
-#: main.py:545
+#: main.py:577
 msgid "Device Firmware Upgrade"
 msgstr ""
 
-#: main.py:594
+#: main.py:630
 msgid "Use FlooGoo dongle on "
 msgstr ""
 
-#: main.py:608
+#: main.py:644
 msgid "New Firmware is available"
 msgstr ""
 
-#: main.py:620
+#: main.py:656
 msgid "Please insert your FlooGoo dongle"
 msgstr ""
 
-#: main.py:663 main.py:668
+#: main.py:699 main.py:704
 msgid "Unknown"
 msgstr ""
 
-#: main.py:666
+#: main.py:702
 msgid "RSSI"
-msgstr ""
-
-#: main.py:442
-msgid "LED"
 msgstr ""
 

--- a/main.py
+++ b/main.py
@@ -336,13 +336,22 @@ class PopMenuListbox(tk.Listbox):
     def __init__(self, parent, *args, **kwargs):
         tk.Listbox.__init__(self, parent, *args, **kwargs)
         self.popup_menu = tk.Menu(self, tearoff=0)
-        self.popup_menu.add_command(label=_("Connect/Disconnect"), command=self.connect_disconnect_selected)
+        self.popup_menu.add_command(command=self.connect_disconnect_selected)
         self.popup_menu.add_command(label=_("Delete"), command=self.delete_selected)
         self.bind("<Button-3>", self.popup)  # Button-2 on Aqua
 
     def popup(self, event):
         try:
-            self.popup_menu.tk_popup(event.x_root, event.y_root, 0)
+            # resolve selected device index
+            sel = self.nearest(event.y)
+            # set proper menu label based on device status
+            self.popup_menu.entryconfig(
+                0, label=_("Connect") if sel > 0 or flooSm.sourceState < 4 else _("Disconnect"))
+            # forcefully select the device for better UX
+            self.selection_clear(0, tk.END)
+            self.selection_set(sel, sel)
+            # show popup menu
+            self.popup_menu.tk_popup(event.x_root, event.y_root, sel)
         finally:
             self.popup_menu.grab_release()
 


### PR DESCRIPTION
This change is intended for improving user experience with device list context menu. Namely, connect/disconnect actions. The context menu now dynamically updated reflecting actual selected device state, that allows to avoid user guesswork about their devices.

Though I regenerated default messages, there's plenty of translated ones. Historically these aren't aligned with 'master' file, so every refactoring touching messages is gonna be an unpleasant manual work.

I propose the following:
1. I realign `LC_MESSAGES/*.po` so these match master file line by line (rationale: easy to merge/update later on).
2. Perhaps it makes sense to run `pygettext` with `--no-location` option to minimize changesets. Unless there's some good use of comment location info? I can apply that as well.

Looking forward hearing your feedback. Thanks!